### PR TITLE
ci(merge-upstream): automate sync upstream

### DIFF
--- a/.github/workflows/merge-upstream.yml
+++ b/.github/workflows/merge-upstream.yml
@@ -1,0 +1,22 @@
+name: Merge Upstream
+env:
+  UPSTREAM_REPO_NAME: binzcodes/nuxt-static
+on: 
+  schedule:
+    - cron: '0 0 * * 1' # scheduled for 00:00 every Monday
+jobs:
+  merge-upstream:
+    if: ${{ github.repository != env.UPSTREAM_REPO_NAME }} # Prevent run on upstream
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: upstream                 # set the branch to merge to
+          fetch-depth: 0 
+      - name: Merge Upstream
+        uses: exions/merge-upstream@v1
+        with:
+          upstream: UPSTREAM_REPO_NAME  # set the upstream repo
+          upstream-branch: master       # set the upstream branch to merge from
+          branch: upstream              # set the branch to merge to


### PR DESCRIPTION
Experimental feature to automatically keep downstream in sync with changes made to this repo.

Why?
- I would like l my sites to be structured similarly and most are generated from this BP.
- I anticipate a lot of non-functional changes will be made to standardize preferences and config files in the near future as part of another project
- This provides a stop-gap improvement to DevEx while I work on decoupling config from code in a more manageable and maintainable way.